### PR TITLE
Adopt a barcode interface

### DIFF
--- a/src/Core/Barcode.js
+++ b/src/Core/Barcode.js
@@ -1,0 +1,8 @@
+// @flow
+
+import type { SymbologySymbol } from "./Characters"
+
+export interface Barcode<T: SymbologySymbol> {
+	encoded: T[];
+	plainTextContent: string;
+}

--- a/src/Core/Barcode.js
+++ b/src/Core/Barcode.js
@@ -1,8 +1,10 @@
 // @flow
 
-import type { SymbologySymbol } from "./Characters"
+import type { SymbologySymbol, TwoWidthSymbologySymbol } from "./Characters"
 
 export interface Barcode<T: SymbologySymbol> {
 	encoded: T[];
 	plainTextContent: string;
 }
+
+export type TwoWidthBarcode = Barcode<TwoWidthSymbologySymbol>

--- a/src/Core/Characters.js
+++ b/src/Core/Characters.js
@@ -1,5 +1,14 @@
 // @flow
-export const WIDE_BAR = "W"
-export const NARROW_BAR = "N"
-export const WIDE_SPACE = "w"
-export const NARROW_SPACE = "n"
+export opaque type WideBar = "W"
+export const WIDE_BAR: WideBar = "W"
+
+export opaque type NarrowBar = "N"
+export const NARROW_BAR: NarrowBar = "N"
+
+export opaque type WideSpace = "w"
+export const WIDE_SPACE: WideSpace = "w"
+
+export opaque type NarrowSpace = "n"
+export const NARROW_SPACE: NarrowSpace = "n"
+
+export opaque type DiscreteSymbologySymbol = WideBar | NarrowBar | WideSpace | WideBar

--- a/src/Core/Characters.js
+++ b/src/Core/Characters.js
@@ -11,5 +11,5 @@ export const WIDE_SPACE: WideSpace = "w"
 export opaque type NarrowSpace = "n"
 export const NARROW_SPACE: NarrowSpace = "n"
 
-export type DiscreteSymbologySymbol = WideBar | NarrowBar | WideSpace | WideBar
+export type DiscreteSymbologySymbol = WideBar | NarrowBar | WideSpace | NarrowSpace
 export type SymbologySymbol = DiscreteSymbologySymbol

--- a/src/Core/Characters.js
+++ b/src/Core/Characters.js
@@ -11,5 +11,5 @@ export const WIDE_SPACE: WideSpace = "w"
 export opaque type NarrowSpace = "n"
 export const NARROW_SPACE: NarrowSpace = "n"
 
-export type DiscreteSymbologySymbol = WideBar | NarrowBar | WideSpace | NarrowSpace
-export type SymbologySymbol = DiscreteSymbologySymbol
+export type TwoWidthSymbologySymbol = WideBar | NarrowBar | WideSpace | NarrowSpace
+export type SymbologySymbol = TwoWidthSymbologySymbol

--- a/src/Core/Characters.js
+++ b/src/Core/Characters.js
@@ -11,5 +11,5 @@ export const WIDE_SPACE: WideSpace = "w"
 export opaque type NarrowSpace = "n"
 export const NARROW_SPACE: NarrowSpace = "n"
 
-export opaque type DiscreteSymbologySymbol = WideBar | NarrowBar | WideSpace | WideBar
-export opaque type SymbologySymbol = DiscreteSymbologySymbol
+export type DiscreteSymbologySymbol = WideBar | NarrowBar | WideSpace | WideBar
+export type SymbologySymbol = DiscreteSymbologySymbol

--- a/src/Core/Characters.js
+++ b/src/Core/Characters.js
@@ -12,3 +12,4 @@ export opaque type NarrowSpace = "n"
 export const NARROW_SPACE: NarrowSpace = "n"
 
 export opaque type DiscreteSymbologySymbol = WideBar | NarrowBar | WideSpace | WideBar
+export opaque type SymbologySymbol = DiscreteSymbologySymbol

--- a/src/Renderers/HTMLRenderer.js
+++ b/src/Renderers/HTMLRenderer.js
@@ -1,10 +1,11 @@
 // @flow
 import { NARROW_SPACE, WIDE_SPACE, NARROW_BAR, WIDE_BAR } from "../Core/Characters"
+import type { TwoWidthBarcode } from "../Core/Barcode"
 
-export function renderBarcodeToHTML(input: string, prefix: string = "bcjs"): string {
+export function renderBarcodeToHTML(input: TwoWidthBarcode, prefix: string = "bcjs"): string {
 	let html = ""
 
-	for (const char of input) {
+	for (const char of input.encoded) {
 		switch (char) {
 			case NARROW_SPACE:
 				html += `<i class="${prefix}-narrow ${prefix}-space"></i>`

--- a/src/Renderers/SVGRenderer.js
+++ b/src/Renderers/SVGRenderer.js
@@ -1,7 +1,7 @@
 // @flow
 import { NARROW_SPACE, WIDE_SPACE, NARROW_BAR, WIDE_BAR } from "../Core/Characters"
 import type { TwoWidthSymbologySymbol } from "../Core/Characters"
-import type { Barcode } from "../Core/Barcode"
+import type { Barcode, TwoWidthBarcode } from "../Core/Barcode"
 
 const NARROW_WIDTH = 1
 const WIDE_WIDTH = 3
@@ -13,7 +13,7 @@ export function rect(x: number, wide: boolean, filled: boolean): string {
 }
 
 export function renderBarcodeToSVG(
-	input: Barcode<TwoWidthSymbologySymbol>,
+	input: TwoWidthBarcode,
 	{ width, height }: { width?: number, height?: number } = {},
 ): string {
 	let svg = ""

--- a/src/Renderers/SVGRenderer.js
+++ b/src/Renderers/SVGRenderer.js
@@ -1,6 +1,6 @@
 // @flow
 import { NARROW_SPACE, WIDE_SPACE, NARROW_BAR, WIDE_BAR } from "../Core/Characters"
-import type { DiscreteSymbologySymbol } from "../Core/Characters"
+import type { TwoWidthSymbologySymbol } from "../Core/Characters"
 import type { Barcode } from "../Core/Barcode"
 
 const NARROW_WIDTH = 1
@@ -13,7 +13,7 @@ export function rect(x: number, wide: boolean, filled: boolean): string {
 }
 
 export function renderBarcodeToSVG(
-	input: Barcode<DiscreteSymbologySymbol>,
+	input: Barcode<TwoWidthSymbologySymbol>,
 	{ width, height }: { width?: number, height?: number } = {},
 ): string {
 	let svg = ""

--- a/src/Renderers/SVGRenderer.js
+++ b/src/Renderers/SVGRenderer.js
@@ -1,5 +1,7 @@
 // @flow
 import { NARROW_SPACE, WIDE_SPACE, NARROW_BAR, WIDE_BAR } from "../Core/Characters"
+import type { DiscreteSymbologySymbol } from "../Core/Characters"
+import type { Barcode } from "../Core/Barcode"
 
 const NARROW_WIDTH = 1
 const WIDE_WIDTH = 3
@@ -10,11 +12,14 @@ export function rect(x: number, wide: boolean, filled: boolean): string {
 		: "white"}"/>`
 }
 
-export function renderBarcodeToSVG(input: string, { width, height }: { width?: number, height?: number } = {}): string {
+export function renderBarcodeToSVG(
+	input: Barcode<DiscreteSymbologySymbol>,
+	{ width, height }: { width?: number, height?: number } = {},
+): string {
 	let svg = ""
 	let x = 0
 
-	for (const char of input) {
+	for (const char of input.encoded) {
 		switch (char) {
 			case NARROW_SPACE:
 				svg += rect(x, false, false)

--- a/src/Renderers/__tests__/SVGRenderer.js
+++ b/src/Renderers/__tests__/SVGRenderer.js
@@ -3,7 +3,7 @@ import { NARROW_BAR, NARROW_SPACE, WIDE_BAR, WIDE_SPACE } from "../../Core/Chara
 
 describe("renderBarcodeToSVG", function() {
 	it("emits as many rects as there are bars in the barcode", function() {
-		const code = [NARROW_SPACE, NARROW_BAR, WIDE_SPACE, WIDE_BAR].join("")
-		expect(renderBarcodeToSVG(code, 100, 5).match(/<rect/g)).toHaveLength(4)
+		const code = [NARROW_SPACE, NARROW_BAR, WIDE_SPACE, WIDE_BAR]
+		expect(renderBarcodeToSVG({ encoded: code }, 100, 5).match(/<rect/g)).toHaveLength(4)
 	})
 })

--- a/src/Symbologies/Code39.js
+++ b/src/Symbologies/Code39.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Barcode } from "../Core/Barcode"
+import type { Barcode, TwoWidthBarcode } from "../Core/Barcode"
 import type { TwoWidthSymbologySymbol } from "../Core/Characters"
 import { NARROW_BAR, NARROW_SPACE, WIDE_BAR, WIDE_SPACE } from "../Core/Characters"
 
@@ -229,7 +229,7 @@ function _encodeContent(text: string, fallbackChar: string): TwoWidthSymbologySy
 	return flattened
 }
 
-export function encodeCode39(text: string, fallbackChar: string = "-"): Barcode<TwoWidthSymbologySymbol> {
+export function encodeCode39(text: string, fallbackChar: string = "-"): TwoWidthBarcode {
 	if (!Mapping.hasOwnProperty(fallbackChar)) {
 		fallbackChar = "-"
 	}

--- a/src/Symbologies/Code39.js
+++ b/src/Symbologies/Code39.js
@@ -214,17 +214,19 @@ Mapping["%"] = [
 ]
 
 function _encodeContent(text: string, fallbackChar: string): DiscreteSymbologySymbol[] {
-	const encodedCharacters: DiscreteSymbologySymbol[] = text
+	const encodedCharacters: DiscreteSymbologySymbol[][] = text
 		.toUpperCase()
 		.split("")
 		.map(character => (Mapping[character] ? Mapping[character] : Mapping[fallbackChar]))
 
-	const flattenedIncludingSeparators: DiscreteSymbologySymbol[] = encodedCharacters.map(encodedCharacter => [
+	const encodedIncludingSeparators: DiscreteSymbologySymbol[][] = encodedCharacters.map(encodedCharacter => [
 		...encodedCharacter,
 		NARROW_SPACE,
 	])
 
-	return flattenedIncludingSeparators
+	const flattened: DiscreteSymbologySymbol[] = Array.prototype.concat.apply([], encodedIncludingSeparators)
+
+	return flattened
 }
 
 export function encodeCode39(text: string, fallbackChar: string = "-"): Barcode<DiscreteSymbologySymbol> {

--- a/src/Symbologies/Code39.js
+++ b/src/Symbologies/Code39.js
@@ -1,7 +1,7 @@
 // @flow
 import { WIDE_BAR, NARROW_BAR, WIDE_SPACE, NARROW_SPACE } from "../Core/Characters"
-import type {DiscreteSymbologySymbol} from "../Core/Characters"
-import type {Barcode} from "../Core/Barcode"
+import type { DiscreteSymbologySymbol } from "../Core/Characters"
+import type { Barcode } from "../Core/Barcode"
 
 // See https://en.wikipedia.org/wiki/Code_39
 export const Mapping = {}
@@ -218,7 +218,7 @@ export function encodeCode39(text: string, fallbackChar: string = "-"): Barcode<
 		fallbackChar = "-"
 	}
 
-	const encoded = (
+	const encoded =
 		Mapping["*"] +
 		NARROW_SPACE +
 		text
@@ -228,7 +228,6 @@ export function encodeCode39(text: string, fallbackChar: string = "-"): Barcode<
 			.map(it => it + NARROW_SPACE)
 			.join("") +
 		Mapping["*"]
-	)
 
 	return {
 		encoded,

--- a/src/Symbologies/Code39.js
+++ b/src/Symbologies/Code39.js
@@ -1,5 +1,7 @@
 // @flow
 import { WIDE_BAR, NARROW_BAR, WIDE_SPACE, NARROW_SPACE } from "../Core/Characters"
+import type {DiscreteSymbologySymbol} from "../Core/Characters"
+import type {Barcode} from "../Core/Barcode"
 
 // See https://en.wikipedia.org/wiki/Code_39
 export const Mapping = {}
@@ -211,12 +213,12 @@ Mapping["%"] = [
 	NARROW_BAR,
 ].join("")
 
-export function encodeCode39(text: string, fallbackChar: string = "-"): string {
+export function encodeCode39(text: string, fallbackChar: string = "-"): Barcode<DiscreteSymbologySymbol> {
 	if (!Mapping.hasOwnProperty(fallbackChar)) {
 		fallbackChar = "-"
 	}
 
-	return (
+	const encoded = (
 		Mapping["*"] +
 		NARROW_SPACE +
 		text
@@ -227,4 +229,9 @@ export function encodeCode39(text: string, fallbackChar: string = "-"): string {
 			.join("") +
 		Mapping["*"]
 	)
+
+	return {
+		encoded,
+		plainTextContent: text,
+	}
 }

--- a/src/Symbologies/Code39.js
+++ b/src/Symbologies/Code39.js
@@ -1,10 +1,10 @@
 // @flow
 import type { Barcode } from "../Core/Barcode"
-import type { DiscreteSymbologySymbol } from "../Core/Characters"
+import type { TwoWidthSymbologySymbol } from "../Core/Characters"
 import { NARROW_BAR, NARROW_SPACE, WIDE_BAR, WIDE_SPACE } from "../Core/Characters"
 
 // See https://en.wikipedia.org/wiki/Code_39
-export const Mapping: { [key: string]: DiscreteSymbologySymbol[] } = {}
+export const Mapping: { [key: string]: TwoWidthSymbologySymbol[] } = {}
 const BaseMapping = {}
 const Bars = [
 	[
@@ -213,29 +213,29 @@ Mapping["%"] = [
 	NARROW_BAR,
 ]
 
-function _encodeContent(text: string, fallbackChar: string): DiscreteSymbologySymbol[] {
-	const encodedCharacters: DiscreteSymbologySymbol[][] = text
+function _encodeContent(text: string, fallbackChar: string): TwoWidthSymbologySymbol[] {
+	const encodedCharacters: TwoWidthSymbologySymbol[][] = text
 		.toUpperCase()
 		.split("")
 		.map(character => (Mapping[character] ? Mapping[character] : Mapping[fallbackChar]))
 
-	const encodedIncludingSeparators: DiscreteSymbologySymbol[][] = encodedCharacters.map(encodedCharacter => [
+	const encodedIncludingSeparators: TwoWidthSymbologySymbol[][] = encodedCharacters.map(encodedCharacter => [
 		...encodedCharacter,
 		NARROW_SPACE,
 	])
 
-	const flattened: DiscreteSymbologySymbol[] = Array.prototype.concat.apply([], encodedIncludingSeparators)
+	const flattened: TwoWidthSymbologySymbol[] = Array.prototype.concat.apply([], encodedIncludingSeparators)
 
 	return flattened
 }
 
-export function encodeCode39(text: string, fallbackChar: string = "-"): Barcode<DiscreteSymbologySymbol> {
+export function encodeCode39(text: string, fallbackChar: string = "-"): Barcode<TwoWidthSymbologySymbol> {
 	if (!Mapping.hasOwnProperty(fallbackChar)) {
 		fallbackChar = "-"
 	}
 
-	const encodedContent: DiscreteSymbologySymbol[] = _encodeContent(text, fallbackChar)
-	const encoded: DiscreteSymbologySymbol[] = [...Mapping["*"], NARROW_SPACE, ...encodedContent, ...Mapping["*"]]
+	const encodedContent: TwoWidthSymbologySymbol[] = _encodeContent(text, fallbackChar)
+	const encoded: TwoWidthSymbologySymbol[] = [...Mapping["*"], NARROW_SPACE, ...encodedContent, ...Mapping["*"]]
 
 	return {
 		encoded,

--- a/src/Symbologies/Code39.js
+++ b/src/Symbologies/Code39.js
@@ -216,7 +216,7 @@ Mapping["%"] = [
 function _encodeContent(text: string, fallbackChar: string): DiscreteSymbologySymbol[] {
 	const encodedCharacters: DiscreteSymbologySymbol[] = text
 		.toUpperCase()
-		.split()
+		.split("")
 		.map(character => (Mapping[character] ? Mapping[character] : Mapping[fallbackChar]))
 
 	const flattenedIncludingSeparators: DiscreteSymbologySymbol[] = encodedCharacters.map(encodedCharacter => [

--- a/src/Symbologies/__tests__/Code39.js
+++ b/src/Symbologies/__tests__/Code39.js
@@ -4,19 +4,19 @@ import { encodeCode39, Mapping } from "../Code39"
 describe("encodeCode39", function() {
 	describe("Delimiters", function() {
 		it("starts the barcode with a start/stop code", function() {
-			const code = encodeCode39("")
-			expect(code.substr(0, 9)).toEqual(Mapping["*"])
+			const code = encodeCode39("").encoded
+			expect(code.slice(0, 9)).toEqual(Mapping["*"])
 		})
 
 		it("ends the barcode with a start/stop code", function() {
-			const code = encodeCode39("")
-			expect(code.substr(-9)).toEqual(Mapping["*"])
+			const code = encodeCode39("").encoded
+			expect(code.slice(-9)).toEqual(Mapping["*"])
 		})
 	})
 
 	it("separates codes with a narrow space", function() {
-		const code = encodeCode39("")
-		expect(code.substr(9, 1)).toEqual("n")
+		const code = encodeCode39("").encoded
+		expect(code.slice(9, 10)).toEqual([NARROW_SPACE])
 	})
 
 	it("matches the snapshot for the full alphabet", function() {
@@ -25,23 +25,23 @@ describe("encodeCode39", function() {
 				.filter(it => it !== "*")
 				.sort()
 				.join(""),
-		)
+		).encoded.join("")
 		expect(code).toMatchSnapshot()
 	})
 
 	it("uppercases input strings", function() {
-		const code = encodeCode39("a")
-		expect(code).not.toEqual(expect.stringContaining(Mapping["-"]))
+		const code = encodeCode39("a").encoded.join("")
+		expect(code).not.toEqual(expect.stringContaining(Mapping["-"].join("")))
 	})
 
 	it("replaces out of range chars", function() {
-		const code = encodeCode39("_")
-		expect(code.substr(10, 9)).toEqual(Mapping["-"])
+		const code = encodeCode39("_").encoded
+		expect(code.slice(10, 19)).toEqual(Mapping["-"])
 	})
 
 	it("replaces out of range chars with custom char", function() {
-		const code = encodeCode39("_", " ")
-		expect(code.substr(10, 9)).toEqual(Mapping[" "])
+		const code = encodeCode39("_", " ").encoded
+		expect(code.slice(10, 19)).toEqual(Mapping[" "])
 	})
 
 	describe("Mapping", function() {
@@ -51,15 +51,15 @@ describe("encodeCode39", function() {
 
 		Object.keys(Mapping).map(char => {
 			it(`matches the snapshot for '${char}'`, function() {
-				expect(Mapping[char]).toMatchSnapshot()
+				expect(Mapping[char].join("")).toMatchSnapshot()
 			})
 
 			it(`maps '${char}' to 5 bars`, function() {
-				expect(Mapping[char].split("").filter(it => it === NARROW_BAR || it === WIDE_BAR)).toHaveLength(5)
+				expect(Mapping[char].filter(it => it === NARROW_BAR || it === WIDE_BAR)).toHaveLength(5)
 			})
 
 			it(`maps '${char}' to 4 spaces`, function() {
-				expect(Mapping[char].split("").filter(it => it === NARROW_SPACE || it === WIDE_SPACE)).toHaveLength(4)
+				expect(Mapping[char].filter(it => it === NARROW_SPACE || it === WIDE_SPACE)).toHaveLength(4)
 			})
 		})
 	})

--- a/src/Symbologies/__tests__/Code39.js
+++ b/src/Symbologies/__tests__/Code39.js
@@ -25,7 +25,7 @@ describe("encodeCode39", function() {
 				.filter(it => it !== "*")
 				.sort()
 				.join(""),
-		).encoded.join("")
+		).encoded
 		expect(code).toMatchSnapshot()
 	})
 
@@ -51,7 +51,7 @@ describe("encodeCode39", function() {
 
 		Object.keys(Mapping).map(char => {
 			it(`matches the snapshot for '${char}'`, function() {
-				expect(Mapping[char].join("")).toMatchSnapshot()
+				expect(Mapping[char]).toMatchSnapshot()
 			})
 
 			it(`maps '${char}' to 5 bars`, function() {

--- a/src/Symbologies/__tests__/Code39.js
+++ b/src/Symbologies/__tests__/Code39.js
@@ -30,8 +30,8 @@ describe("encodeCode39", function() {
 	})
 
 	it("uppercases input strings", function() {
-		const code = encodeCode39("a").encoded.join("")
-		expect(code).not.toEqual(expect.stringContaining(Mapping["-"].join("")))
+		const code = encodeCode39("a").encoded
+		expect(code.slice(10, 19)).toEqual(Mapping["A"])
 	})
 
 	it("replaces out of range chars", function() {

--- a/src/Symbologies/__tests__/__snapshots__/Code39.js.snap
+++ b/src/Symbologies/__tests__/__snapshots__/Code39.js.snap
@@ -1,91 +1,1071 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`encodeCode39 Mapping matches the snapshot for ' ' 1`] = `"NwWnNnWnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for ' ' 1`] = `
+Array [
+  "N",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '$' 1`] = `"NwNwNwNnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for '$' 1`] = `
+Array [
+  "N",
+  "w",
+  "N",
+  "w",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '%' 1`] = `"NnNwNwNwN"`;
+exports[`encodeCode39 Mapping matches the snapshot for '%' 1`] = `
+Array [
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "w",
+  "N",
+  "w",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '*' 1`] = `"NwNnWnWnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for '*' 1`] = `
+Array [
+  "N",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '+' 1`] = `"NwNnNwNwN"`;
+exports[`encodeCode39 Mapping matches the snapshot for '+' 1`] = `
+Array [
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "w",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '.' 1`] = `"WwNnNnWnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for '.' 1`] = `
+Array [
+  "W",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '/' 1`] = `"NwNwNnNwN"`;
+exports[`encodeCode39 Mapping matches the snapshot for '/' 1`] = `
+Array [
+  "N",
+  "w",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '-' 1`] = `"NwNnNnWnW"`;
+exports[`encodeCode39 Mapping matches the snapshot for '-' 1`] = `
+Array [
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '0' 1`] = `"NnNwWnWnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for '0' 1`] = `
+Array [
+  "N",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '1' 1`] = `"WnNwNnNnW"`;
+exports[`encodeCode39 Mapping matches the snapshot for '1' 1`] = `
+Array [
+  "W",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '2' 1`] = `"NnWwNnNnW"`;
+exports[`encodeCode39 Mapping matches the snapshot for '2' 1`] = `
+Array [
+  "N",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '3' 1`] = `"WnWwNnNnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for '3' 1`] = `
+Array [
+  "W",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '4' 1`] = `"NnNwWnNnW"`;
+exports[`encodeCode39 Mapping matches the snapshot for '4' 1`] = `
+Array [
+  "N",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '5' 1`] = `"WnNwWnNnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for '5' 1`] = `
+Array [
+  "W",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '6' 1`] = `"NnWwWnNnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for '6' 1`] = `
+Array [
+  "N",
+  "n",
+  "W",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '7' 1`] = `"NnNwNnWnW"`;
+exports[`encodeCode39 Mapping matches the snapshot for '7' 1`] = `
+Array [
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '8' 1`] = `"WnNwNnWnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for '8' 1`] = `
+Array [
+  "W",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for '9' 1`] = `"NnWwNnWnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for '9' 1`] = `
+Array [
+  "N",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'A' 1`] = `"WnNnNwNnW"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'A' 1`] = `
+Array [
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'B' 1`] = `"NnWnNwNnW"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'B' 1`] = `
+Array [
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'C' 1`] = `"WnWnNwNnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'C' 1`] = `
+Array [
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'D' 1`] = `"NnNnWwNnW"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'D' 1`] = `
+Array [
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'E' 1`] = `"WnNnWwNnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'E' 1`] = `
+Array [
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'F' 1`] = `"NnWnWwNnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'F' 1`] = `
+Array [
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'G' 1`] = `"NnNnNwWnW"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'G' 1`] = `
+Array [
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'H' 1`] = `"WnNnNwWnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'H' 1`] = `
+Array [
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'I' 1`] = `"NnWnNwWnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'I' 1`] = `
+Array [
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'J' 1`] = `"NnNnWwWnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'J' 1`] = `
+Array [
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "W",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'K' 1`] = `"WnNnNnNwW"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'K' 1`] = `
+Array [
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'L' 1`] = `"NnWnNnNwW"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'L' 1`] = `
+Array [
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'M' 1`] = `"WnWnNnNwN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'M' 1`] = `
+Array [
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'N' 1`] = `"NnNnWnNwW"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'N' 1`] = `
+Array [
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'O' 1`] = `"WnNnWnNwN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'O' 1`] = `
+Array [
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'P' 1`] = `"NnWnWnNwN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'P' 1`] = `
+Array [
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'Q' 1`] = `"NnNnNnWwW"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'Q' 1`] = `
+Array [
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'R' 1`] = `"WnNnNnWwN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'R' 1`] = `
+Array [
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'S' 1`] = `"NnWnNnWwN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'S' 1`] = `
+Array [
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'T' 1`] = `"NnNnWnWwN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'T' 1`] = `
+Array [
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "w",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'U' 1`] = `"WwNnNnNnW"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'U' 1`] = `
+Array [
+  "W",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'V' 1`] = `"NwWnNnNnW"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'V' 1`] = `
+Array [
+  "N",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'W' 1`] = `"WwWnNnNnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'W' 1`] = `
+Array [
+  "W",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'X' 1`] = `"NwNnWnNnW"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'X' 1`] = `
+Array [
+  "N",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'Y' 1`] = `"WwNnWnNnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'Y' 1`] = `
+Array [
+  "W",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 Mapping matches the snapshot for 'Z' 1`] = `"NwWnWnNnN"`;
+exports[`encodeCode39 Mapping matches the snapshot for 'Z' 1`] = `
+Array [
+  "N",
+  "w",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+]
+`;
 
-exports[`encodeCode39 matches the snapshot for the full alphabet 1`] = `"NwNnWnWnNnNwWnNnWnNnNwNwNwNnNnNnNwNwNwNnNwNnNwNwNnNwNnNnWnWnWwNnNnWnNnNwNwNnNwNnNnNwWnWnNnWnNwNnNnWnNnWwNnNnWnWnWwNnNnNnNnNwWnNnWnWnNwWnNnNnNnWwWnNnNnNnNwNnWnWnWnNwNnWnNnNnWwNnWnNnWnNnNwNnWnNnWnNwNnWnWnWnNwNnNnNnNnWwNnWnWnNnWwNnNnNnWnWwNnNnNnNnNwWnWnWnNnNwWnNnNnWnNwWnNnNnNnWwWnNnWnNnNnNwWnNnWnNnNwWnWnWnNnNwNnNnNnWnNwWnWnNnWnNwNnNnWnWnNwNnNnNnNnWwWnWnNnNnWwNnNnWnNnWwNnNnNnWnWwNnWwNnNnNnWnNwWnNnNnWnWwWnNnNnNnNwNnWnNnWnWwNnWnNnNnNwWnWnNnNnNwNnWnWnN"`;
+exports[`encodeCode39 matches the snapshot for the full alphabet 1`] = `
+Array [
+  "N",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "w",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "w",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "w",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+  "n",
+  "N",
+  "n",
+  "N",
+  "w",
+  "N",
+  "n",
+  "W",
+  "n",
+  "W",
+  "n",
+  "N",
+]
+`;


### PR DESCRIPTION
Instead of passing the encoded barcode as a string, pass it as an object including the original text and the encoded version.

This also changes the encoding format from string to array of symbols. This allows for better type checking as well.

```js
export interface Barcode<T: SymbologySymbol> {
	encoded: T[];
	plainTextContent: string;
}
```

As I intend to support other symbologies (many-width) Barcode is generic to allow Renderers to indicate their supported symbologies.